### PR TITLE
Added Mish activation function

### DIFF
--- a/torchtoolbox/nn/activation.py
+++ b/torchtoolbox/nn/activation.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # @Author  : DevinYang(pistonyang@gmail.com)
-__all__ = ['Activation', 'Swish']
+__all__ = ['Activation', 'Swish', 'Mish']
 
-from .functional import swish
+from .functional import swish, mish
 from torch import nn
 from torch.nn import functional as F
 
@@ -22,6 +22,22 @@ class Swish(nn.Module):
 
     def forward(self, x):
         return swish(x, self.beta)
+    
+    
+class Mish(nn.Module):
+    """Mish activation from 'Mish: A Self Regularized Non-Monotonic Activation Function'
+        https://www.bmvc2020-conference.com/assets/papers/0928.pdf
+
+        mish =  x*tanh(softplus(x))
+        d_mish = delta(x)swish(x, beta=1) + mish(x)/x
+
+    """
+
+    def __init__(self):
+        super(Mish, self).__init__()
+
+    def forward(self, x):
+        return mish(x)
 
 
 # class HardSwish(nn.Module):
@@ -59,6 +75,8 @@ class Activation(nn.Module):
                 else nn.Hardsigmoid(**kwargs)
         elif act_type == 'swish':
             self.act = Swish(**kwargs)
+        elif act_type == 'mish':
+            self.act = Mish()
         elif act_type == 'sigmoid':
             self.act = nn.Sigmoid()
         elif act_type == 'lrelu':

--- a/torchtoolbox/nn/functional.py
+++ b/torchtoolbox/nn/functional.py
@@ -76,6 +76,15 @@ def swish(x, beta=1.0):
     return SwishOP.apply(x, beta)
 
 
+def mish(x):
+    """Mish activation.
+    'https://www.bmvc2020-conference.com/assets/papers/0928.pdf'
+    Args:
+        x: Input tensor.
+    """
+    return x * torch.tanh(F.softplus(x))
+
+
 @torch.no_grad()
 def smooth_one_hot(true_labels: torch.Tensor, classes: int, smoothing=0.0):
     """


### PR DESCRIPTION
Reference: https://www.bmvc2020-conference.com/assets/papers/0928.pdf
I didn't implement the backward pass using an autograd function like in the case of swish because of the internal stable differentiation of thresholded softplus. 